### PR TITLE
refactor: add matUtils_overlap parameter to configuration and workflows

### DIFF
--- a/assets/test/input/params_newick.json
+++ b/assets/test/input/params_newick.json
@@ -6,6 +6,7 @@
     "tree_file_format": "newick",
     "lineages": "${projectDir}/assets/test/input/lineages.tsv",
     "barcode_prefix": "RSVa",
+    "matUtils_overlap": 0.8,
 
     "outdir": "results"
 }

--- a/assets/test/input/params_nexus.json
+++ b/assets/test/input/params_nexus.json
@@ -6,6 +6,7 @@
     "tree_file_format": "nexus",
     "lineages": "${projectDir}/assets/test/input/lineages.tsv",
     "barcode_prefix": "RSVa",
+    "matUtils_overlap": 0.8,
 
     "outdir": "results"
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -46,7 +46,6 @@ process {
 
     withName: 'MATUTILS_ANNOTATE' {
         cpus = { check_max( 5 * task.attempt, 'cpus' ) }
-        ext.args = '--set-overlap 0.8'
         publishDir = [
             path: { "${params.outdir}/matutils_annotate" },
             mode: params.publish_dir_mode,

--- a/modules/local/matutils/annotate/main.nf
+++ b/modules/local/matutils/annotate/main.nf
@@ -7,6 +7,7 @@ process MATUTILS_ANNOTATE {
     input:
     path protobuf_tree_file
     path clades
+    val matUtils_overlap
 
     output:
     path 'annotated_tree.pb', emit: annotated_tree_file
@@ -18,6 +19,7 @@ process MATUTILS_ANNOTATE {
     matUtils \\
         annotate \\
         ${args} \\
+        --set-overlap ${matUtils_overlap} \\
         -i ${protobuf_tree_file} \\
         -c ${clades} \\
         -o annotated_tree.pb

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,7 @@ params {
 
     lineages                    = null
     barcode_prefix              = 'pathogen'
+    matUtils_overlap            = 0
 
     // Boilerplate options
     outdir                       = "results"

--- a/workflows/barcodeforge.nf
+++ b/workflows/barcodeforge.nf
@@ -34,6 +34,7 @@ workflow BARCODEFORGE {
     MATUTILS_ANNOTATE(
         USHER.out.protobuf_tree,
         params.lineages,
+        params.matUtils_overlap,
     )
 
     MATUTILS_EXTRACT(


### PR DESCRIPTION
This pull request introduces a new parameter, `matUtils_overlap`, to enhance the flexibility of the MATUTILS_ANNOTATE process by allowing users to configure the overlap threshold dynamically. The changes span configuration files, input JSON files, and workflow scripts to ensure consistent integration of this new parameter.

### Addition of `matUtils_overlap` parameter:

* **Configuration files:**
  - Added `matUtils_overlap` to the `params` block in `nextflow.config`, with a default value of `0`.

* **Input JSON files:**
  - Included the `matUtils_overlap` parameter with a value of `0.8` in `params_newick.json` and `params_nexus.json` to support testing with different tree file formats. [[1]](diffhunk://#diff-68657cd37d95372d31abfde559a306811f6d9f2cf4481ec67761753fd2bc0dadR9) [[2]](diffhunk://#diff-785ede2ec0ccccab1b371f5690edb2bb475511763604bc94f70377712e0a2e4eR9)

### Workflow updates:

* **MATUTILS_ANNOTATE process:**
  - Updated the `MATUTILS_ANNOTATE` process in `modules/local/matutils/annotate/main.nf` to accept `matUtils_overlap` as an input parameter and pass it to the `matUtils annotate` command via the `--set-overlap` flag. [[1]](diffhunk://#diff-7e0c6f0a18539a1a043b5b04b42e11ce98803f38a171a95c4f9c72bbec50e29eR10) [[2]](diffhunk://#diff-7e0c6f0a18539a1a043b5b04b42e11ce98803f38a171a95c4f9c72bbec50e29eR22)
  - Removed the hardcoded `--set-overlap 0.8` argument from the `conf/modules.config` file to allow dynamic configuration.

* **Workflow invocation:**
  - Modified the `workflow BARCODEFORGE` in `workflows/barcodeforge.nf` to pass `params.matUtils_overlap` to the `MATUTILS_ANNOTATE` process.