### PR TITLE
Some smaller suggestions

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -11,9 +11,9 @@
 process {
 
     // TODO nf-core: Check the defaults for all processes
-    cpus   = { 1      * task.attempt }
-    memory = { 6.GB   * task.attempt }
-    time   = { 4.h    * task.attempt }
+    cpus          = { 1 * task.attempt }
+    memory        = { 6.GB * task.attempt }
+    time          = { 4.h * task.attempt }
 
     errorStrategy = { task.exitStatus in ((130..145) + 104) ? 'retry' : 'finish' }
     maxRetries    = 1
@@ -26,36 +26,36 @@ process {
     //        adding in your local modules too.
     // TODO nf-core: Customise requirements for specific processes.
     // See https://www.nextflow.io/docs/latest/config.html#config-process-selectors
-    withLabel:process_single {
-        cpus   = { 1                   }
+    withLabel: process_single {
+        cpus   = { 1 }
         memory = { 6.GB * task.attempt }
-        time   = { 4.h  * task.attempt }
+        time   = { 4.h * task.attempt }
     }
-    withLabel:process_low {
-        cpus   = { 2     * task.attempt }
+    withLabel: process_low {
+        cpus   = { 2 * task.attempt }
         memory = { 12.GB * task.attempt }
-        time   = { 4.h   * task.attempt }
+        time   = { 4.h * task.attempt }
     }
-    withLabel:process_medium {
-        cpus   = { 6     * task.attempt }
+    withLabel: process_medium {
+        cpus   = { 6 * task.attempt }
         memory = { 36.GB * task.attempt }
-        time   = { 8.h   * task.attempt }
+        time   = { 8.h * task.attempt }
     }
-    withLabel:process_high {
-        cpus   = { 12    * task.attempt }
+    withLabel: process_high {
+        cpus   = { 12 * task.attempt }
         memory = { 72.GB * task.attempt }
-        time   = { 16.h  * task.attempt }
+        time   = { 16.h * task.attempt }
     }
-    withLabel:process_long {
-        time   = { 20.h  * task.attempt }
+    withLabel: process_long {
+        time = { 20.h * task.attempt }
     }
-    withLabel:process_high_memory {
+    withLabel: process_high_memory {
         memory = { 200.GB * task.attempt }
     }
-    withLabel:error_ignore {
+    withLabel: error_ignore {
         errorStrategy = 'ignore'
     }
-    withLabel:error_retry {
+    withLabel: error_retry {
         errorStrategy = 'retry'
         maxRetries    = 2
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -16,7 +16,7 @@ process {
         mode: params.publish_dir_mode,
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
-    
+
     withName: 'MINIMAP2_ALIGN' {
         cpus = { check_max( 5 * task.attempt, 'cpus' ) }
         publishDir = [
@@ -46,7 +46,7 @@ process {
 
     withName: 'MATUTILS_ANNOTATE' {
         cpus = { check_max( 5 * task.attempt, 'cpus' ) }
-        ext.args = '--set-overlap 0.8'
+        ext.args = '--set-overlap 0'
         publishDir = [
             path: { "${params.outdir}/matutils_annotate" },
             mode: params.publish_dir_mode,
@@ -74,7 +74,7 @@ process {
 
     withName: 'GENERATE_BARCODES' {
         cpus = { check_max( 5 * task.attempt, 'cpus' ) }
-        ext.args = '--set-overlap 1.0'
+        ext.args = '--set-overlap 0'
         publishDir = [
             path: { "${params.outdir}/barcode" },
             mode: params.publish_dir_mode,

--- a/conf/test.config
+++ b/conf/test.config
@@ -14,7 +14,7 @@ process {
     resourceLimits = [
         cpus: 4,
         memory: '15.GB',
-        time: '1.h'
+        time: '1.h',
     ]
 }
 
@@ -25,7 +25,6 @@ params {
     // Input data
     // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
-    fasta = "${projectDir}/assets/test/input/sra/input.tsv"
-    is_aligned = false
-    
+    fasta                      = "${projectDir}/assets/test/input/sra/input.tsv"
+    is_aligned                 = false
 }

--- a/main.nf
+++ b/main.nf
@@ -13,9 +13,9 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { BARCODEFORGE } from './workflows/barcodeforge'
+include { BARCODEFORGE            } from './workflows/barcodeforge'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_barcodeforge_pipeline'
-include { PIPELINE_COMPLETION } from './subworkflows/local/utils_nfcore_barcodeforge_pipeline'
+include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_barcodeforge_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/modules/local/format_tree/environment.yml
+++ b/modules/local/format_tree/environment.yml
@@ -2,8 +2,10 @@ name: format_nwk_tree
 channels:
   - conda-forge
   - bioconda
+  - anaconda
 dependencies:
   - python=3.11.4
+  - git==2.45.2
   - pip:
     - ete3==3.1.3
     - git+https://github.com/jeetsukumaran/DendroPy.git@26c3bfba473ddee5db2856c79b7f22702ce903e1#egg=DendroPy

--- a/modules/local/format_tree/main.nf
+++ b/modules/local/format_tree/main.nf
@@ -4,7 +4,6 @@ process FORMAT_TREE {
 
     conda "${moduleDir}/environment.yml"
 
-
     input:
     path tree_file
     val tree_file_format

--- a/nextflow.config
+++ b/nextflow.config
@@ -212,7 +212,7 @@ validation {
     defaultIgnoreParams    = []
     help {
         enabled = true
-        command = "nextflow run $manifest.name -profile <conda/mamba> --params <PARAMS.json> --outdir <OUTDIR>"
+        command = "nextflow run $manifest.name -profile <conda/mamba> -params-file <PARAMS.json> --outdir <OUTDIR>"
         fullParameter = "help_full"
         showHiddenParameter = "show_hidden"
         beforeText = """

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,8 @@ params {
     outdir                       = "results"
     publish_dir_mode             = 'copy'
     validate_params              = true
+    help                         = false
+    help_full                    = false
     version                      = false
     trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')// Config options
     max_cpus                     = 16
@@ -198,7 +200,33 @@ manifest {
 }
 
 plugins {
-    id 'nf-schema@2.1.1' // Validation of pipeline parameters
+    id 'nf-schema@2.3.0' // Validation of pipeline parameters
+}
+
+validation {
+    monochromeLogs         = false
+    help.showHidden        = false
+    lentientMode           = false
+    failUnrecognisedParams = false
+    ignoreParamsFile       = []
+    defaultIgnoreParams    = []
+    help {
+        enabled = true
+        command = "nextflow run $manifest.name -profile <docker/singularity/conda> --params <PARAMS.json> --outdir <OUTDIR>"
+        fullParameter = "help_full"
+        showHiddenParameter = "show_hidden"
+        beforeText = """
+-\033[2m----------------------------------------------------\033[0m-
+\033[0;35m  ${manifest.name} ${manifest.version}\033[0m
+-\033[2m----------------------------------------------------\033[0m-
+"""
+        afterText = """${manifest.doi ? "* The pipeline\n" : ""}${manifest.doi.tokenize(",").collect { "  https://doi.org/${it.trim().replace('https://doi.org/','')}"}.join("\n")}${manifest.doi ? "\n" : ""}
+"""
+    }
+    summary {
+        beforeText = validation.help.beforeText
+        afterText = validation.help.afterText
+    }
 }
 
 // Load modules.config for DSL2 module specific options

--- a/nextflow.config
+++ b/nextflow.config
@@ -212,7 +212,7 @@ validation {
     defaultIgnoreParams    = []
     help {
         enabled = true
-        command = "nextflow run $manifest.name -profile <docker/singularity/conda> --params <PARAMS.json> --outdir <OUTDIR>"
+        command = "nextflow run $manifest.name -profile <conda/mamba> --params <PARAMS.json> --outdir <OUTDIR>"
         fullParameter = "help_full"
         showHiddenParameter = "show_hidden"
         beforeText = """

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -13,17 +13,22 @@
       "properties": {
         "tree_file": {
           "type": "string",
+          "description": "Path to the phylogenetic tree file (supports Newick and Nexus formats).",
           "fa_icon": "fas fa-tree"
         },
         "tree_file_format": {
           "type": "string",
-          "default": "newick"
+          "description": "Format of the tree file (\"newick\" or \"nexus\").",
+          "default": "newick",
+          "enum": ["newick", "nexus"]
         },
         "lineages": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the TSV file containing lineage definitions."
         },
         "barcode_prefix": {
           "type": "string",
+          "description": "A prefix string added to all generated barcodes (e.g. <prefix>-<lineage>).",
           "default": "pathogen",
           "fa_icon": "fas fa-barcode"
         }
@@ -37,10 +42,12 @@
       "default": "",
       "properties": {
         "reference_genome": {
-          "type": "string"
+          "type": "string",
+          "description": "Path to the reference genome file used for alignment."
         },
         "alignment": {
           "type": "string",
+          "description": "Path to the aligned FASTA file required for barcode generation.",
           "fa_icon": "fas fa-stream"
         }
       },
@@ -55,6 +62,7 @@
       "properties": {
         "outdir": {
           "type": "string",
+          "description": "Directory where the pipeline output (barcodes and logs) will be stored.",
           "default": "results",
           "fa_icon": "fas fa-folder-open"
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -12,7 +12,7 @@
       "default": "",
       "properties": {
         "tree_file": {
-          "type": "string",
+          "type": "file-path",
           "description": "Path to the phylogenetic tree file (supports Newick and Nexus formats).",
           "fa_icon": "fas fa-tree"
         },
@@ -23,8 +23,8 @@
           "enum": ["newick", "nexus"]
         },
         "lineages": {
-          "type": "string",
-          "description": "Path to the TSV file containing lineage definitions."
+          "type": "file-path",
+          "description": "two-column tsv file with lineage assignment, clades in the first column and sample identifiers in the second"
         },
         "barcode_prefix": {
           "type": "string",
@@ -42,11 +42,11 @@
       "default": "",
       "properties": {
         "reference_genome": {
-          "type": "string",
+          "type": "file-path",
           "description": "Path to the reference genome file used for alignment."
         },
         "alignment": {
-          "type": "string",
+          "type": "file-path",
           "description": "Path to the aligned FASTA file required for barcode generation.",
           "fa_icon": "fas fa-stream"
         }

--- a/subworkflows/local/utils_nfcore_barcodeforge_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_barcodeforge_pipeline/main.nf
@@ -9,10 +9,10 @@
 */
 
 
-include { completionSummary } from '../../nf-core/utils_nfcore_pipeline'
-include { UTILS_NFCORE_PIPELINE } from '../../nf-core/utils_nfcore_pipeline'
+include { completionSummary       } from '../../nf-core/utils_nfcore_pipeline'
+include { UTILS_NFCORE_PIPELINE   } from '../../nf-core/utils_nfcore_pipeline'
 include { UTILS_NEXTFLOW_PIPELINE } from '../../nf-core/utils_nextflow_pipeline'
-include { VALIDATE } from '../../../modules/local/validate'
+include { VALIDATE                } from '../../../modules/local/validate'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -22,10 +22,10 @@ include { VALIDATE } from '../../../modules/local/validate'
 
 workflow PIPELINE_INITIALISATION {
     take:
-    version // boolean: Display version and exit
-    validate_params // boolean: Boolean whether to validate parameters against the schema at runtime
+    version           // boolean: Display version and exit
+    validate_params   // boolean: Boolean whether to validate parameters against the schema at runtime
     nextflow_cli_args //   array: List of positional nextflow CLI args
-    outdir //  string: The output directory where the results will be saved
+    outdir            //  string: The output directory where the results will be saved
 
     main:
 

--- a/subworkflows/local/utils_nfcore_barcodeforge_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_barcodeforge_pipeline/main.nf
@@ -46,9 +46,9 @@ workflow PIPELINE_INITIALISATION {
     //
     if (validate_params) {
         VALIDATE(
-            params.lineages,
-            params.tree_file,
-            params.alignment,
+            Channel.fromPath(params.lineages, checkIfExists:true),
+            Channel.fromPath(params.tree_file, checkIfExists:true),
+            Channel.fromPath(params.alignment, checkIfExists:true),
             params.tree_file_format,
         )
     }
@@ -61,7 +61,7 @@ workflow PIPELINE_INITIALISATION {
     )
 
     emit:
-    versions = ch_versions
+    versions  = ch_versions
 }
 
 /*

--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -10,9 +10,9 @@
 
 workflow UTILS_NEXTFLOW_PIPELINE {
     take:
-    print_version // boolean: print version
-    dump_parameters // boolean: dump parameters
-    outdir //    path: base directory used to publish pipeline results
+    print_version        // boolean: print version
+    dump_parameters      // boolean: dump parameters
+    outdir               //    path: base directory used to publish pipeline results
     check_conda_channels // boolean: check conda channels
 
     main:

--- a/workflows/barcodeforge.nf
+++ b/workflows/barcodeforge.nf
@@ -22,10 +22,11 @@ workflow BARCODEFORGE {
 
     ch_versions = Channel.empty()
 
-    FATOVCF(params.alignment)
+    FATOVCF(Channel.fromPath(params.alignment, checkIfExists: true))
+        .set { ch_faToVcf_versions }
 
     FORMAT_TREE(
-        params.tree_file,
+        Channel.fromPath(params.tree_file, checkIfExists: true),
         params.tree_file_format,
     )
 
@@ -33,7 +34,7 @@ workflow BARCODEFORGE {
 
     MATUTILS_ANNOTATE(
         USHER.out.protobuf_tree,
-        params.lineages,
+        Channel.fromPath(params.lineages, checkIfExists: true),
     )
 
     MATUTILS_EXTRACT(
@@ -41,10 +42,10 @@ workflow BARCODEFORGE {
     )
 
     ADD_REF_MUTS(
-        params.reference_genome,
+        Channel.fromPath(params.reference_genome, checkIfExists: true),
         MATUTILS_EXTRACT.out.sample_paths_file,
         MATUTILS_EXTRACT.out.lineage_definition_file,
-        params.alignment,
+        Channel.fromPath(params.alignment, checkIfExists: true),
     )
 
     GENERATE_BARCODES(ADD_REF_MUTS.out.modified_lineage_paths, params.barcode_prefix)

--- a/workflows/barcodeforge.nf
+++ b/workflows/barcodeforge.nf
@@ -4,13 +4,13 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 include { softwareVersionsToYAML } from '../subworkflows/nf-core/utils_nfcore_pipeline'
-include { FATOVCF } from '../modules/local/faToVcf/main.nf'
-include { USHER } from '../modules/local/usher/main.nf'
-include { MATUTILS_ANNOTATE } from '../modules/local/matutils/annotate/main.nf'
-include { MATUTILS_EXTRACT } from '../modules/local/matutils/extract/main.nf'
-include { ADD_REF_MUTS } from '../modules/local/add_ref_muts/main.nf'
-include { GENERATE_BARCODES } from '../modules/local/generate_barcodes/main.nf'
-include { FORMAT_TREE } from '../modules/local/format_tree/main.nf'
+include { FATOVCF                } from '../modules/local/faToVcf/main.nf'
+include { USHER                  } from '../modules/local/usher/main.nf'
+include { MATUTILS_ANNOTATE      } from '../modules/local/matutils/annotate/main.nf'
+include { MATUTILS_EXTRACT       } from '../modules/local/matutils/extract/main.nf'
+include { ADD_REF_MUTS           } from '../modules/local/add_ref_muts/main.nf'
+include { GENERATE_BARCODES      } from '../modules/local/generate_barcodes/main.nf'
+include { FORMAT_TREE            } from '../modules/local/format_tree/main.nf'
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     RUN MAIN WORKFLOW


### PR DESCRIPTION
- Ran [`nextflow lint`](https://www.nextflow.io/docs/latest/reference/cli.html#lint) 
- Added `--help` command 
> `nextflow run andersen-lab/BarcodeForge --help`
- Added file checking logic for creation of nextflow channels
- Added missing dependency of `environment.yml` file when running ``nextflow run andersen-lab/BarcodeForge -profile docker,wave ...`


Other then that I think it would be good to have the `.nf-core.yml in there` so you can use `nf-core modules update <tool-name>`. 

Think also a good alternative solution to the `--set-overlap 0.8` is to do something like this, so that in the params file, you can also tweak that. 
`nextflow.config`: 
```nextflow file=nextflow.config
matutils_annotate_arguments = '--set-overlap 0.8' 
```
`modules.config`
```nextflow file=modules.config
withName: 'MATUTILS_ANNOTATE' {
        ext.args = "${params.matutils_annotate_arguments}"
```
 
