### PR TITLE
chore: remove unused imports and variables

### DIFF
--- a/barcodeforge/cli.py
+++ b/barcodeforge/cli.py
@@ -318,7 +318,6 @@ def extract_auspice_data(
     Inspired by Dr. John Huddleston's Gist on processing Auspice JSON files.
     Source: https://gist.github.com/huddlej/5d7bd023d3807c698bd18c706974f2db
     """
-    is_debug = ctx.obj.get("DEBUG", False)  # More robust way to get debug status
     print_info(f"Processing Auspice JSON file:\t{auspice_json_path}", bold=True)
     process_auspice_json(
         tree_json_path=auspice_json_path,

--- a/barcodeforge/generate_barcodes.py
+++ b/barcodeforge/generate_barcodes.py
@@ -4,7 +4,7 @@
 
 import pandas as pd
 import rich_click as click
-from .utils import sortFun, print_error, print_success, print_info, print_debug
+from .utils import sortFun, print_error, print_success, print_info
 
 
 def parse_tree_paths(df: pd.DataFrame) -> pd.DataFrame:

--- a/barcodeforge/plot_barcode.py
+++ b/barcodeforge/plot_barcode.py
@@ -1,7 +1,7 @@
 """Plot barcode from CSV file."""
 
 import pandas as pd
-from .utils import sortFun, print_info, print_debug
+from .utils import print_info, print_debug
 import seaborn as sns
 import matplotlib.pyplot as plt
 from matplotlib.colors import ListedColormap
@@ -46,7 +46,6 @@ def create_barcode_visualization(
     # Prepare chunks
     chunks = []
     dims = []
-    cat_dtype = pd.CategoricalDtype(categories=base_list, ordered=True)
     for i in range(num_chunks):
         ps = all_pos[i * CHUNK : (i + 1) * CHUNK]
         sub = plot_df[plot_df.pos.isin(ps)]

--- a/barcodeforge/ref_muts.py
+++ b/barcodeforge/ref_muts.py
@@ -2,7 +2,7 @@ import pandas as pd
 from Bio import SeqIO
 from collections import OrderedDict
 import re
-from .utils import print_error, print_warning, print_success, print_info, print_debug
+from .utils import print_warning, print_success, print_info, print_debug
 
 
 def _load_sample_mutations(path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,9 +90,7 @@ def test_barcode_command_default_options(runner, temp_files, mocker):
         "barcodeforge.cli.create_barcodes_from_lineage_paths"
     )
     mock_create_plot = mocker.patch("barcodeforge.cli.create_barcode_plot")
-    mock_cli_console = mocker.patch.object(
-        barcodeforge.utils, "console", MagicMock(spec=Console)
-    )
+    mocker.patch.object(barcodeforge.utils, "console", MagicMock(spec=Console))
 
     args = [
         "barcode",
@@ -225,9 +223,7 @@ def test_barcode_command_custom_options(runner, temp_files, mocker):
         "barcodeforge.cli.create_barcodes_from_lineage_paths"
     )
     mock_create_plot = mocker.patch("barcodeforge.cli.create_barcode_plot")
-    mock_cli_console = mocker.patch.object(
-        barcodeforge.utils, "console", MagicMock(spec=Console)
-    )
+    mocker.patch.object(barcodeforge.utils, "console", MagicMock(spec=Console))
 
     prefix = "MYPREFIX"
     custom_usher_args = "-U -l"
@@ -376,9 +372,7 @@ def test_barcode_command_nexus_tree(runner, temp_files, mocker):
     mocker.patch("barcodeforge.cli.process_and_reroot_lineages")
     mocker.patch("barcodeforge.cli.create_barcodes_from_lineage_paths")
     mocker.patch("barcodeforge.cli.create_barcode_plot")
-    mock_cli_console = mocker.patch.object(
-        barcodeforge.utils, "console", MagicMock(spec=Console)
-    )
+    mocker.patch.object(barcodeforge.utils, "console", MagicMock(spec=Console))
 
     args = [
         "barcode",
@@ -432,9 +426,7 @@ def test_barcode_command_newick_tree_reformat(runner, temp_files, mocker):
     mocker.patch("barcodeforge.cli.process_and_reroot_lineages")
     mocker.patch("barcodeforge.cli.create_barcodes_from_lineage_paths")
     mocker.patch("barcodeforge.cli.create_barcode_plot")
-    mock_cli_console = mocker.patch.object(
-        barcodeforge.utils, "console", MagicMock(spec=Console)
-    )
+    mocker.patch.object(barcodeforge.utils, "console", MagicMock(spec=Console))
 
     args = [
         "barcode",

--- a/tests/test_format_tree.py
+++ b/tests/test_format_tree.py
@@ -2,7 +2,6 @@ import pytest
 from pathlib import Path
 from barcodeforge.format_tree import convert_nexus_to_newick, _remove_quotes_from_file
 import tempfile
-import os
 
 # Sample Nexus content
 SAMPLE_NEXUS_CONTENT = """

--- a/tests/test_generate_barcodes.py
+++ b/tests/test_generate_barcodes.py
@@ -12,7 +12,6 @@ from barcodeforge.generate_barcodes import (
     create_barcodes_from_lineage_paths,
     check_allele_consistency,
 )
-from barcodeforge.utils import sortFun  # Assuming sortFun is in utils
 
 
 # Sample data for testing

--- a/tests/test_plot_barcode.py
+++ b/tests/test_plot_barcode.py
@@ -1,10 +1,7 @@
 import pytest
 import pandas as pd
 from pathlib import Path
-from barcodeforge.plot_barcode import create_barcode_visualization, create_barcode_plot
-import matplotlib.pyplot as plt
-import seaborn as sns
-from matplotlib.colors import ListedColormap
+from barcodeforge.plot_barcode import create_barcode_visualization
 
 
 @pytest.fixture

--- a/tests/test_ref_muts.py
+++ b/tests/test_ref_muts.py
@@ -3,11 +3,9 @@ import pandas as pd
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 from collections import OrderedDict
-from pathlib import Path
 import copy  # Ensure copy is imported
-from unittest.mock import MagicMock, call  # For console mocking
+from unittest.mock import MagicMock  # For console mocking
 from rich.console import Console  # For console spec
-import barcodeforge.utils
 from barcodeforge.ref_muts import (
     _load_sample_mutations,
     _extract_mutations,
@@ -74,11 +72,6 @@ def test_load_sample_mutations(sample_muts_file):
 
 
 def test_extract_mutations():
-    sample_with_muts = {"mutations": "gene1:A123T,C456G>gene2:X1Y"}
-    extracted = _extract_mutations(sample_with_muts)
-    expected = OrderedDict(
-        [("gene2:X1Y", ["gene2:X1Y"]), ("gene1:A123T,C456G", ["gene1:A123T", "C456G"])]
-    )
     # The original code's MUT_PATTERN and splitting logic might be different.
     # This test is based on a common interpretation. Adjust if your MUT_PATTERN is more complex.
     # Based on the provided code: MUT_PATTERN = re.compile(r"([^:]+):([A-Za-z0-9,]+)")


### PR DESCRIPTION
This pull request primarily focuses on code cleanup and minor refactoring across several modules and tests. The main changes involve removing unused imports, cleaning up test mocks, and simplifying code where possible. These changes help improve code readability and maintainability without affecting functionality.

**Code cleanup and import management:**

* Removed unused imports such as `sortFun`, `print_error`, and `print_debug` from `barcodeforge/generate_barcodes.py`, `barcodeforge/plot_barcode.py`, and `barcodeforge/ref_muts.py` to reduce clutter and potential confusion. [[1]](diffhunk://#diff-bfe77b724771c698316685ff0d6783fdc744ac2923ea717b659daaf0e4ce7327L7-R7) [[2]](diffhunk://#diff-00d60cd06d5925605f27acb83754066444428815e87d2acc4bebfc2e91e7df11L4-R4) [[3]](diffhunk://#diff-541ef09095dc674bf6730d76590bc5a80a0ef092866b21d7e257295957ff9371L5-R5)
* Removed unnecessary imports from test files, including `os`, `matplotlib`, `seaborn`, `ListedColormap`, and others, to streamline the test environment. [[1]](diffhunk://#diff-72ef5c8d13d7a326ba02388f70239e7f0911b1635bc777ca6feaf8a1a8124e81L5) [[2]](diffhunk://#diff-bfc5526ac9827976415f7b7991941dd3fd72a24bf09b3b2069999da3e96ab4faL4-R4) [[3]](diffhunk://#diff-21ed4643052ac9adc47cd74312d928e0b4fa400ca251b6a8169f371dceb9f26aL15) [[4]](diffhunk://#diff-3be46708c3d08eabf7caa9337b3b94bd334269041ce7a81f8fdb6bf2d4772a45L6-L10)

